### PR TITLE
Secure matcha and suggestion APIs with token authentication

### DIFF
--- a/src/app/api/matcha/route.ts
+++ b/src/app/api/matcha/route.ts
@@ -1,8 +1,17 @@
 import { NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Matcha from "@/models/Matcha";
+import { getUserFromRequest } from "@/lib/auth";
 
 export async function POST(req: Request) {
+  const user = getUserFromRequest(req);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (user.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
   await dbConnect();
   const data = await req.json();
   const newMatcha = await Matcha.create(data);

--- a/src/app/api/suggest/route.ts
+++ b/src/app/api/suggest/route.ts
@@ -1,8 +1,14 @@
 import { NextResponse } from "next/server";
 import mongoose from "mongoose";
 import { SuggestedMatcha } from "@/models/SuggestedMatcha";
+import { getUserFromRequest } from "@/lib/auth";
 
 export async function POST(req: Request) {
+  const user = getUserFromRequest(req);
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const body = await req.json();
 
   try {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,17 @@
+export interface AuthenticatedUser {
+  role: "admin" | "user";
+}
+
+export function getUserFromRequest(req: Request): AuthenticatedUser | null {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) return null;
+
+  const token = authHeader.slice(7);
+  if (token === process.env.ADMIN_TOKEN) {
+    return { role: "admin" };
+  }
+  if (token === process.env.USER_TOKEN) {
+    return { role: "user" };
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add simple token-based authentication helper
- require admin token for adding new matcha items
- require authentication for submitting matcha suggestions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68952758d26c8325a125327f1b0e7082