### PR TITLE
Use shared dbConnect and validate SuggestedMatcha inputs

### DIFF
--- a/src/app/api/suggest/route.ts
+++ b/src/app/api/suggest/route.ts
@@ -1,12 +1,47 @@
 import { NextResponse } from "next/server";
-import mongoose from "mongoose";
 import { SuggestedMatcha } from "@/models/SuggestedMatcha";
+import dbConnect from "@/lib/mongodb";
+
+interface SuggestedMatchaInput {
+  brand: string;
+  name: string;
+  link: string;
+  notes?: string;
+}
+
+function validateSuggestedMatcha(data: unknown): data is SuggestedMatchaInput {
+  if (!data || typeof data !== "object") return false;
+  const { brand, name, link, notes } = data as Record<string, unknown>;
+  if (typeof brand !== "string" || !brand.trim()) return false;
+  if (typeof name !== "string" || !name.trim()) return false;
+  if (typeof link !== "string") return false;
+  try {
+    new URL(link);
+  } catch {
+    return false;
+  }
+  if (notes !== undefined && typeof notes !== "string") return false;
+  return true;
+}
 
 export async function POST(req: Request) {
   const body = await req.json();
 
+  if (!validateSuggestedMatcha(body)) {
+    return NextResponse.json({ success: false, error: "Invalid input" }, { status: 400 });
+  }
+
   try {
-    await mongoose.connect(process.env.MONGODB_URI!);
+    await dbConnect();
+  } catch (err) {
+    console.error("❌ Database connection error:", err);
+    return NextResponse.json(
+      { success: false, error: "Database connection error" },
+      { status: 500 }
+    );
+  }
+
+  try {
     const matcha = await SuggestedMatcha.create(body);
     return NextResponse.json({ success: true, matcha });
   } catch (err) {


### PR DESCRIPTION
## Summary
- replace direct mongoose connection with shared dbConnect utility
- validate SuggestedMatcha input structure before persistence
- handle database connection failures with graceful error responses

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689527577f24832581760626645cb757